### PR TITLE
Polyfill.io fix

### DIFF
--- a/eatlas_spatial_publisher.info
+++ b/eatlas_spatial_publisher.info
@@ -13,12 +13,6 @@ scripts[] = js/eAtlas_spatial_publisher_back_to_top_button.js
 stylesheets[all][] = ../../../libraries/openlayers/ol.css
 scripts[] = ../../../libraries/openlayers/ol.js
 
-; NOTE: OpenLayers require PolyFill added to the page header in order to work on broken web browsers (such as IE)
-;   Add the following line to your "html.tpl.php"
-;   <script src="https://cdnjs.cloudflare.com/polyfill/v2/polyfill.min.js?features=requestAnimationFrame,Element.prototype.classList,URL"></script>
-
-; https://cdnjs.cloudflare.com/polyfill/v2/polyfill.min.js?features=requestAnimationFrame,Element.prototype.classList,URL
-
 package = eAtlas
 
 configure = admin/config/eatlas/eatlas_spatial_publisher

--- a/eatlas_spatial_publisher.info
+++ b/eatlas_spatial_publisher.info
@@ -15,9 +15,9 @@ scripts[] = ../../../libraries/openlayers/ol.js
 
 ; NOTE: OpenLayers require PolyFill added to the page header in order to work on broken web browsers (such as IE)
 ;   Add the following line to your "html.tpl.php"
-;   <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=requestAnimationFrame,Element.prototype.classList,URL"></script>
+;   <script src="https://cdnjs.cloudflare.com/polyfill/v2/polyfill.min.js?features=requestAnimationFrame,Element.prototype.classList,URL"></script>
 
-; https://cdn.polyfill.io/v2/polyfill.min.js?features=requestAnimationFrame,Element.prototype.classList,URL
+; https://cdnjs.cloudflare.com/polyfill/v2/polyfill.min.js?features=requestAnimationFrame,Element.prototype.classList,URL
 
 package = eAtlas
 


### PR DESCRIPTION
Marc determined that polyfill is for supporting browsers older than 2017 and so no longer required. I have included a commit that changes the URL of polyfill to a cloudflare mirror so we can revert to that if we want to.